### PR TITLE
add cart item links and remove index.html from links

### DIFF
--- a/src/js/productList.mjs
+++ b/src/js/productList.mjs
@@ -16,7 +16,7 @@ function productCardTemplate(product) {
     const discountAmount = Math.round(product.SuggestedRetailPrice - product.FinalPrice);
    
     return `<li class="product-card">
-        <a href="product_pages/index.html?product=${product.Id}">
+        <a href="product_pages/?product=${product.Id}">
             <img
                 src="${product.Image}"
                 alt="${product.NameWithoutBrand}"

--- a/src/js/shoppingCart.mjs
+++ b/src/js/shoppingCart.mjs
@@ -18,13 +18,13 @@ export default async function shoppingCart() {
 
 function cartItemTemplate(item) {
   const newItem = `<li class="cart-card divider">
-  <a href="#" class="cart-card__image">
+  <a href="../product_pages/?product=${item.Id}" class="cart-card__image">
     <img
       src="${item.Image}"
       alt="${item.Name}"
     />
   </a>
-  <a href="#">
+  <a href="../product_pages/?product=${item.Id}">
     <h2 class="card__name">${item.Name}</h2>
   </a>
   <p class="cart-card__color">${item.Colors[0].ColorName}</p>

--- a/src/public/partials/header.html
+++ b/src/public/partials/header.html
@@ -1,10 +1,10 @@
 <!-- header.html -->
 <div class="logo">
   <img src="/images/noun_Tent_2517.svg" alt="tent image for logo" />
-  <a href="/index.html"> Sleep<span class="highlight">Outside</span></a>
+  <a href="/"> Sleep<span class="highlight">Outside</span></a>
 </div>
 <div class="cart">
-  <a href="/cart/index.html" aria-label="View your cart and items in it">
+  <a href="/cart/" aria-label="View your cart and items in it">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
       <path
         d="M18.9 32.6c1.1 2.4 2.5 3.3 5.4 3.3 1.6 0 3.6-0.3 5.9-0.6 3.2-0.5 6.9-1 11.2-1 2.1 0 4.3 0.1 6.4 0.3 2.1 0.1 4.2 0.3 6.1 0.3 3.2 0 5.2-0.4 5.9-1.2 2.7-2.7 2.8-8.8 2.9-14.6 0.1-6.7 0.2-14.5 4.6-18.7 -0.5 0-1 0-1.6 0 -14.2 0-37.5 0-41.1 0C15.6 6.2 14.9 23.6 18.9 32.6z"


### PR DESCRIPTION
Added dynamic links to the cart item template so clicking on a cart item title will take you to the product page. Also removed index.html references from the logo, shopping cart, and products. (home is / instead or /index.html, cart is /cart/ instead of /cart/index.html, products are /product_pages/?product=880RR instead of /product_pages/index.html?product=880RR)